### PR TITLE
Add backport-pending label

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -25,4 +25,15 @@ jobs:
         
       - name: Debug log
         if: ${{ failure() }}
-        run: cat ~/.backport/backport.debug.log 
+        run: cat ~/.backport/backport.debug.log
+
+  add-backport-label:
+      if: github.event.pull_request.base.ref == 'master'
+      runs-on: ubuntu-latest
+      permissions: 
+        pull-requests: write
+      steps:
+        - name: Add label with gh CLI
+          run: gh pr edit ${{ github.event.pull_request.number }} --add-label "backport-pending"
+          env:
+            github_token: ${{ secrets.BACKPORT_TOKEN }}


### PR DESCRIPTION
Adds _'backport-pending'_ label whenever a PR is targetting the master branch